### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Updated BetterCloud's vault-java-driver from 3.1.0 to 4.0.0.  The latest driver now supports Hashicorp Vault 1.0 and important features: KV v2 and namespaces.

mvn test showed no errors after changing to version 4.0.0.